### PR TITLE
Update badge link to point to the new project lifecycle documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/org.finos/finos.svg?maxAge=2592000)](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22finos%22)
 [![Renovate](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com)
 ![Build](https://github.com/finos/finos-parent-pom/workflows/finos-parent-pom-build/badge.svg)
-[![FINOS - Incubating](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-incubating.svg)](https://finosfoundation.atlassian.net/wiki/display/FINOS/Incubating)
+[[![FINOS - Incubating](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-incubating.svg)](https://community.finos.org/docs/governance/lifecycle-stages/incubating)](https://community.finos.org/docs/governance/lifecycle-stages/incubating)
 
 # FINOS Parent POM
 This Maven POM aims to provide **_common functionalities to Maven projects_** hosted by FINOS, the Fintech Open Source Foundation.


### PR DESCRIPTION
This PR updates the badge link from `/stages/` to `/lifecycle-stages/` to reflect the new FINOS documentation structure. Please make sure to read and understand the new [FINOS lifecycle stages documentation](https://www.finos.org/blog/updated-finos-project-lifecycle).

- Old format: `https://community.finos.org/docs/governance/software-projects/stages/{stage}/`
- New format: `https://community.finos.org/docs/governance/lifecycle-stages/{stage}`
- Note: `active` stage has been changed to `graduated`

> [!IMPORTANT]
> This PR was generated automatically. We kindly ask you to review it manually, confirm there are no other occurrences of the badge logic in other files, and merge at your earliest convenience. If you have any questions or concerns, please email help@finos.org.