### PR TITLE
Add MAINTAINERS.md file

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,13 @@
+# Maintainers
+
+This file lists the maintainers of this repository and is maintained by the project maintainers team.
+
+The project maintainers team is responsible for ensuring that the MAINTAINERS.md file is updated with the latest changes.
+
+Please email help@finos.org when changes are made to the MAINTAINERS.md file.
+
+For information about maintainer responsibilities and resources, please see the [FINOS Maintainers Cheatsheet](https://community.finos.org/docs/finos-maintainers-cheatsheet).
+
+| GitHub Username | Name | Email |
+|----------------|------|-------|
+| @skuro | Carlo Sciolla | skuro@skuro.tk |


### PR DESCRIPTION
This PR adds a MAINTAINERS.md file listing all repository maintainers.

The maintainers are determined from:
- Users with `maintain` role on the repository
- Teams with `maintain` role on the repository (excluding FINOS organization teams)

Each maintainer entry includes their GitHub username, name, and email from their GitHub profile (if available).

## Review Request

Please review this PR and:
1. **Verify the maintainer list is complete and accurate**
2. **Check that all maintainer details (name, email) are correct**
3. **Update any incorrect information** (names, emails, etc.)**
4. **If there are any missing maintainers** who should be included but were not automatically detected or if any maintainers are missing from the list, please email help@finos.org

If you already have a MAINTAINERS.md file, you can close this PR. Please update your existing file if needed and place it in the root of the repository.

If you notice any issues or missing information, please make the changes directly to this branch. Moving forward keeping this file up to date is the responsibility of the maintainers.

Thank you for your review!